### PR TITLE
Use ES modules

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     plugins: {
         "postcss-import": {},
         "tailwindcss/nesting": {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
-const preset = require('./vendor/filament/filament/tailwind.config.preset')
+import preset from './vendor/filament/filament/tailwind.config.preset'
 
-module.exports = {
+export default {
     presets: [preset],
     content: [
         './app/Filament/**/*.php',


### PR DESCRIPTION
Seems you still use CommonJS in some files, where you could use ES modules.

Changes:
- Renamed `postcss.config.cjs` to `postcss.config.js`
- Use `export default` instead of `module.exports = `
- Use `import` instead of `require`

Tested using `npm run build`