### PR TITLE
Allow directories for make command

### DIFF
--- a/src/Commands/MakeBrickCommand.php
+++ b/src/Commands/MakeBrickCommand.php
@@ -4,6 +4,8 @@ namespace Awcodes\Mason\Commands;
 
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 
 use function Laravel\Prompts\text;
 
@@ -17,13 +19,13 @@ class MakeBrickCommand extends Command
 
     public function handle(): int
     {
-        $brick = (string) str(
-            string: $this->argument('name') ??
-                text(
-                    label: 'What is the brick name?',
-                    placeholder: 'CustomBrick',
-                    required: true,
-                ),
+        $brick = (string) Str::of(
+            $this->argument('name') ??
+            text(
+                label: 'What is the brick name?',
+                placeholder: 'CustomBrick',
+                required: true,
+            )
         )
             ->trim('/')
             ->trim('\\')
@@ -33,25 +35,34 @@ class MakeBrickCommand extends Command
         $namespace = config('mason.generator.namespace');
         $viewsPath = config('mason.generator.views_path');
 
-        $className = (string) str($brick)->afterLast('\\');
-        $fullNamespace = str($namespace) . "\\{$className}";
+        $className = (string) Str::of($brick)->afterLast('\\');
+        $brickNamespace = Str::of($brick)->contains('\\')
+            ? (string) Str::of($brick)->beforeLast('\\')
+            : '';
 
-        $brickLabel = (string) str($className)
+        $fullNamespace = $brickNamespace
+            ? "{$namespace}\\{$brickNamespace}\\{$className}"
+            : "{$namespace}\\{$className}";
+
+        $brickLabel = (string) Str::of($className)
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
 
-        $brickName = (string) str($className)
-            ->afterLast('.')
-            ->lcfirst();
+        $brickName = Str::of($brick)
+            ->explode('\\')
+            ->map(fn ($segment) => Str::kebab($segment))
+            ->implode('.');
 
-        $view = (string) str($className)->kebab();
+        $view = Str::of($brick)
+            ->explode('\\')
+            ->map(fn ($segment) => Str::kebab($segment))
+            ->implode('.');
 
         $classPath = app_path(
-            (string) str($className)
-                ->prepend('/')
-                ->prepend($namespace)
+            (string) Str::of($brick)
+                ->prepend($namespace . '\\')
                 ->replace('\\', '/')
                 ->replace('//', '/')
                 ->replace('App', '')
@@ -59,27 +70,27 @@ class MakeBrickCommand extends Command
         );
 
         $viewPath = resource_path(
-            (string) str($view)
-                ->prepend('/')
-                ->prepend($viewsPath)
-                ->prepend('/views/')
+            (string) Str::of($view)
+                ->prepend($viewsPath . '/')
+                ->prepend('views/')
                 ->replace('.', '/')
-                ->replace('\\', '/')
                 ->replace('//', '/')
                 ->append('.blade.php')
         );
 
-        $files = [
-            $classPath,
-            $viewPath,
-        ];
+        $files = [$classPath, $viewPath];
 
         if (! $this->option('force') && $this->checkForCollision($files)) {
             return static::INVALID;
         }
 
+        File::ensureDirectoryExists(dirname($classPath));
+        File::ensureDirectoryExists(dirname($viewPath));
+
         $this->copyStubToApp('brick-class', $classPath, [
-            'namespace' => $namespace,
+            'namespace' => $brickNamespace
+                ? $namespace . '\\' . $brickNamespace
+                : $namespace,
             'class_name' => $className,
             'brick_name' => $brickName,
             'brick_label' => $brickLabel,


### PR DESCRIPTION
This PR:
- allows to create bricks in directories
- ensures unique identifiers by combining the namespace and the name
- uses `Str` for readability

Examples:
```bash
php artisan make:mason-brick PricingSection
php artisan make:mason-brick Hero/Simple
php artisan make:mason-brick Cta/Simple
php artisan make:mason-brick Deep/Nested/Test
```