### PR TITLE
Consistent icons in sidebar

### DIFF
--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -118,7 +118,7 @@
                         @if ($action->getIcon())
                             <x-filament::icon
                                 :icon="$action->getIcon()"
-                                class="h-5 w-5"
+                                class="h-5 w-5 shrink-0"
                             />
                         @endif
 


### PR DESCRIPTION
When the Brick has a longer label it shrinks the icon down.

Before:
![Screenshot 2025-03-09 at 3 56 43 PM](https://github.com/user-attachments/assets/6c94b297-7df7-412d-9e4c-5d8b36929217)


After:
![Screenshot 2025-03-09 at 3 57 57 PM](https://github.com/user-attachments/assets/5d56bc5b-804b-456b-be6f-e9b7fe3b5be2)
