### PR TITLE
Fix sidebar not re-rendering when brick collection change

### DIFF
--- a/resources/views/mason.blade.php
+++ b/resources/views/mason.blade.php
@@ -57,7 +57,9 @@
             </div>
 
             @if (! $isDisabled && filled($actions))
-                <x-mason::sidebar :actions="$actions" />
+                <div wire:key="sidebar-{{ hash('sha256', json_encode($actions)) }}">
+                    <x-mason::sidebar :actions="$actions" />
+                </div>
             @endif
         </x-filament::input.wrapper>
     </div>


### PR DESCRIPTION
**Issue:**

- The Mason::make('bricks') field is dynamically generated based on the other(live) field.
- When the field is updated, the bricks actions changes accordingly.
- However, the sidebar component fails to refresh, causing outdated actions to persist.

```
ToggleButtons::make('type')
                ->label('Type')
                ->options([
                    'web' => 'Web',
                    'admin' => 'Admin',
                ])
                ->inline()
                ->default('web')
                ->live()
                ->afterStateUpdated(function (Set $set, $state): void {
                    $set('bricks', null);
                })
                ->disabledOn('edit');
                
Mason::make('bricks')
                 ->label('')
                 ->bricks(function (Get $get): array {
                    return $get('type') === 'web'
                      ? BrickCollection::make()
                      : AdminBrickCollection::make();
                 })
                 ->placeholder('Drag and drop bricks to get started...'),
```
