### PR TITLE
Fix: better starting drop zone

### DIFF
--- a/resources/views/iframe-preview-content.blade.php
+++ b/resources/views/iframe-preview-content.blade.php
@@ -9,6 +9,9 @@
                 align-items: center;
                 justify-content: center;
                 color: #9ca3af;
+                position: absolute;
+                inset: 0;
+                margin: 0;
             "
         >
             {{ __('mason::mason.preview.placeholder') }}


### PR DESCRIPTION
Increases drop zone on placeholder to fill the area to make initial block dragging work better.

Closes #27 