### PR TITLE
fix: add missing isFocused property to Alpine component

### DIFF
--- a/resources/js/mason.js
+++ b/resources/js/mason.js
@@ -18,6 +18,7 @@ export default function masonComponent({
         state: state,
         statePath: statePath,
         fullscreen: false,
+        isFocused: false,
         viewport: 'desktop',
         sidebarOpen: true,
         colorMode: hasColorModeToggle


### PR DESCRIPTION
## Description

Fixes a `ReferenceError` that occurs when the Mason Blade view attempts to bind to the `isFocused` property which was missing from the Alpine.js component data object.

## Issue

When loading Mason editor, the following JavaScript error occurs:
```
ReferenceError: isFocused is not defined
```

This happens because the Mason Blade template references the `isFocused` property (likely via `x-bind` or similar Alpine directive), but this property was not initialized in the Alpine component's return object.

## Solution

Added `isFocused: false` to the component data object at line 21 in `resources/js/mason.js`.

## Testing

- ✅ Verified that the Mason editor loads without JavaScript errors
- ✅ Confirmed that blocks render correctly in the iframe preview
- ✅ Tested edit controls work as expected

## Changes

- Added `isFocused: false,` to the Alpine component data object

## Checklist

- [x] Fix has been tested locally
- [x] Code follows the existing style
- [x] No breaking changes introduced