### PR TITLE
feat: add configurable authentication guard

### DIFF
--- a/config/mason.php
+++ b/config/mason.php
@@ -13,4 +13,19 @@ return [
     'entry' => [
         'layout' => 'mason::iframe-entry', // Set to your layout view path, e.g., 'layouts.entry'
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Guard
+    |--------------------------------------------------------------------------
+    |
+    | This option controls which authentication guard Mason routes will use.
+    | If set to null, the default guard from auth.php will be used.
+    | This is useful when using Mason with Filament admin panels that use
+    | custom guards like 'admin', 'web', 'sanctum', etc.
+    |
+    | Example: 'admin' for Filament admin panel
+    |
+    */
+    'guard' => null,
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 use Awcodes\Mason\Http\Controllers\MasonController;
 use Illuminate\Support\Facades\Route;
 
-Route::post('/mason/preview', [MasonController::class, 'preview'])
-    ->name('mason.preview')
-    ->middleware(['web', 'auth']);
+$authMiddleware = config('mason.guard')
+    ? 'auth:' . config('mason.guard')
+    : 'auth';
 
-Route::post('/mason/entry', [MasonController::class, 'entry'])
-    ->name('mason.entry')
-    ->middleware(['web', 'auth']);
+Route::middleware(['web', $authMiddleware])->group(function () {
+    Route::post('/mason/preview', [MasonController::class, 'preview'])
+        ->name('mason.preview');
+
+    Route::post('/mason/entry', [MasonController::class, 'entry'])
+        ->name('mason.entry');
+});


### PR DESCRIPTION
## Description

Adds the ability to configure a custom authentication guard for Mason routes, eliminating the need to override routes in `AppServiceProvider` when using multiple authentication guards.

## Problem

Currently, Mason's routes are hardcoded with the default `auth` middleware, which uses the default authentication guard from `config/auth.php`. This causes issues when:

- Using Filament admin panels with custom guards (e.g., `admin`)
- Running multiple authentication systems (customer vs admin)
- Using API guards like `sanctum` or custom guards

**Current workaround:**
```php
// AppServiceProvider.php - Required workaround
protected function registerMasonRoutes(): void
{
    Route::post('/mason/preview', function (Request $request) {
        return app(\Awcodes\Mason\Http\Controllers\MasonController::class)->preview($request);
    })->middleware(['web', 'auth:admin']); // Must override to use custom guard
}
```

## Solution

Add a simple `guard` configuration option to `config/mason.php`:

```php
return [
    // ... existing config ...
    
    'guard' => null, // null = default guard, 'admin' = admin guard, etc.
];
```

## Changes

### 1. **config/mason.php** - New configuration option
- Added `guard` config option with comprehensive documentation
- Defaults to `null` (uses default auth guard)
- Supports any Laravel authentication guard

### 2. **routes/web.php** - Dynamic guard usage
- Routes now read guard from config
- Maintains backward compatibility
- Clean implementation using route groups

## Usage

### For Filament Admin Panels:
```php
// config/mason.php
'guard' => 'admin',
```

### For API applications:
```php
// config/mason.php
'guard' => 'sanctum',
```

### For default behavior (no change needed):
```php
// config/mason.php
'guard' => null, // Or omit entirely
```

## Benefits

✅ **Simple** - One-line configuration  
✅ **Backward Compatible** - Existing installations work unchanged  
✅ **Flexible** - Works with any Laravel guard  
✅ **Clean** - Removes need for route overrides  
✅ **Well Documented** - Clear config comments  

## Testing

- ✅ Tested with `guard => null` (default behavior maintained)
- ✅ Tested with `guard => 'admin'` (Filament admin panel integration)
- ✅ Verified backward compatibility
- ✅ Confirmed route middleware application

## Related Issues

This addresses a common pain point for users integrating Mason with Filament admin panels and other multi-guard Laravel applications.

## Migration Guide

No migration needed! Existing installations continue working without changes. To use a custom guard:

1. Publish config: `php artisan vendor:publish --tag=mason-config`
2. Set guard: `'guard' => 'admin'` in `config/mason.php`
3. Remove route overrides from `AppServiceProvider` (if any)