### PR TITLE
Fix: Preserve iframe preview when cancelling brick edit modal

### DIFF
--- a/resources/views/mason.blade.php
+++ b/resources/views/mason.blade.php
@@ -71,6 +71,7 @@
             >
                 <div
                     class="mason-editor-wrapper"
+                    wire:ignore
                     {{
                         \Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())->class([
                             "mason-input-wrapper",
@@ -81,7 +82,6 @@
                         x-ref="previewIframe"
                         name="{{ "mason-preview-iframe-" . $statePath }}"
                         class="mason-iframe"
-                        wire:ignore
                     ></iframe>
                 </div>
 


### PR DESCRIPTION
## Problem

When editing a brick and cancelling (or closing) the modal, the iframe preview goes blank. Saving works fine — the issue only occurs when the modal is dismissed without saving.

- Laravel v12.51.0
- Filament v5.2.1
- Livewire v4.1.4
- Mason v3.0.4

## Cause

When a Filament action modal is cancelled, `unmountAction` triggers a Livewire request. The server response causes a DOM morph to update the page. With `wire:ignore` on the `<iframe>` element itself, Livewire's morph algorithm can still replace the element if it cannot match it during tree diffing - the `wire:ignore` attribute is only checked when the morpher updates an existing element, not when it decides to remove and re-insert one.

Once the iframe is replaced, the Alpine component retains a stale reference to the old (now detached) element, and the new empty iframe is never populated with the preview content.

## Solution

Move `wire:ignore` from the `<iframe>` to its parent mason-editor-wrapper `<div>`. This tells Livewire to skip the entire subtree during morphs, preventing the iframe from being replaced.

## Changes

`resources/views/mason.blade.php` — moved `wire:ignore` from `<iframe>` to parent `<div class="mason-editor-wrapper">`.

## How to verify

1. Create a page with a Mason field and add one or more bricks
2. Save the record
3. Edit any brick (click edit or double-click)
4. Cancel the modal without saving
5. Before this fix: iframe preview goes blank
6. After this fix: iframe preview is preserved